### PR TITLE
Switched to tuples in the Vertex formula for C#

### DIFF
--- a/algebra/vertex_formula/csharp/VertexFormula.cs
+++ b/algebra/vertex_formula/csharp/VertexFormula.cs
@@ -4,12 +4,22 @@ namespace csharp
 {
     class VertexFormula
     {
-        public static (double,double) GetVertex(double termA, double termB, double termC = 0.0)
+        public static Tuple<double, double> GetVertex(Tuple<double, double> termA, Tuple<double, double> termB, Tuple<double, double> termC)
         {
-            if(termA == 0.0)
-                throw new Exception("Divide by zero error. Cannot use zero for termA in GetVertex function");
+            if (termA.Item1 == 0)
+            {
+                throw new Exception("Cannot divide by zero in GetVertex function. Term A must contain a non-zero number");
+            }
             else
-                return (((-1 * termB) / (2 * termA)),((4*termA*termC-termB*termB)/(4*termA)));
+            {
+                // First calculate the vertex point
+                var vertexPoint = (-1 * termB.Item1) / (termA.Item1 * 2);
+
+                // Plug the vertexPoint into the formula to retrieve the Y-coordinate
+                var yCord = Math.Pow(termA.Item1 * vertexPoint, termA.Item2) + Math.Pow(termB.Item1 * vertexPoint, termB.Item2) + termC.Item1;
+
+                return Tuple.Create(vertexPoint, yCord);
+            }
         }
     }
 }


### PR DESCRIPTION
#37 

Switching to Tuples, this provides a better data structure for the coordinate system and also, in my opinion, the problem of representing a polynomial expression and objects.

Happy to hear feedback!