### PR TITLE
Adds Matrix operations in Javascript

### DIFF
--- a/linear_algebra/matrix_operations/javascript/matrix_operations.js
+++ b/linear_algebra/matrix_operations/javascript/matrix_operations.js
@@ -25,7 +25,7 @@ const multiply = function(a,b) {
   if (b.length !== a[0].length) {
     throw Error("Matrices must be of sizes [x,y] and [y,z]")
   }
-  return a.map((line) => line.map((_,i) => vector_dot_multiplication(line, b.map((col) => col[i]))));
+  return a.map((line) => line.map((_,i) => dot_multiply(line, b.map((col) => col[i]))));
 }
 
 /***
@@ -43,4 +43,4 @@ const transpose = function(a) {
 }
 
 
-export {add_matrices, dot_multiply, multiply, multiply_scalar, transpose};
+module.exports = {add, dot_multiply, multiply, multiply_scalar, transpose}

--- a/linear_algebra/matrix_operations/javascript/matrix_operations.js
+++ b/linear_algebra/matrix_operations/javascript/matrix_operations.js
@@ -1,0 +1,46 @@
+/***
+Adds two matrices `a` and `b`
+***/
+const add = function(a,b) {
+    if (a.length !== b.length || a[0].length !== b[0].length) {
+      throw Error("Matrices must be of same length.");
+    }
+    return a.map((line, i) => line.map((el, j) => el + b[i][j]));
+}
+
+/***
+Performs a dot-multiplication of two vectors `a`, and `b`
+***/
+const dot_multiply = function (a,b) {
+  if (a.length !== b.length) {
+    throw Error("Vectors must be of same length");
+  }
+  return a.map((el, i) => el * b[i]).reduce((acc, el) => acc + el);
+}
+
+/***
+Performs a matrix multiplication between matrices `a` and `b`
+***/
+const multiply = function(a,b) {
+  if (b.length !== a[0].length) {
+    throw Error("Matrices must be of sizes [x,y] and [y,z]")
+  }
+  return a.map((line) => line.map((_,i) => vector_dot_multiplication(line, b.map((col) => col[i]))));
+}
+
+/***
+Multiplies matrix `a` by an scalar `x`
+***/
+const multiply_scalar = function(a,x) {
+  return a.map((line) =>  line.map(el => x * el));
+}
+
+/***
+Transposes matrix `a`
+***/
+const transpose = function(a) {
+  return a.map((line,i) => line.map((_,j) => a[j][i]));
+}
+
+
+export {add_matrices, dot_multiply, multiply, multiply_scalar, transpose};


### PR DESCRIPTION
I added some Matrix operations in Javascript. I wanted to practice writing more functional-style Javascript, I hope that's not an issue. 

And if you think it's too hard to read, let me know so I can comment the steps better (I must confess even I was a bit confused with some of those `map` operations).

To test, start node on interactive mode:
`node`

Then require the matrix operations module:

`> const Matrix = require('./matrix_operations.js')`

And use as such:

```
> let a = [[1,2,3],[4,5,6],[7,8,9]]
undefined
> let b = [[9,8,7],[6,5,4],[3,2,1]]
undefined
> Matrix.multiply(a,b)
[ [ 30, 24, 18 ], [ 84, 69, 54 ], [ 138, 114, 90 ] ]
> Matrix.add(a,b)
[ [ 10, 10, 10 ], [ 10, 10, 10 ], [ 10, 10, 10 ] ]
> Matrix.multiply_scalar(a,-1)
[ [ -1, -2, -3 ], [ -4, -5, -6 ], [ -7, -8, -9 ] ]
> Matrix.transpose(a)
[ [ 1, 4, 7 ], [ 2, 5, 8 ], [ 3, 6, 9 ] ]

etc...
```
