### PR TITLE
Add tail recursive version of the factorial function

### DIFF
--- a/algebra/factorial/java/factorial_tail_recursive.java
+++ b/algebra/factorial/java/factorial_tail_recursive.java
@@ -1,0 +1,17 @@
+//Java 1.8 or later
+public class factorial_tail_recursive {
+	/*
+	 * This version does'nt causes the StackOverflow exception when n is big
+	 * Long should be the return type to avoid int overflow with big multiplications.
+	 */
+	public static long factorial(int n) {
+		return factorial(n - 1, n);
+	}
+
+	private static long factorial(int n, long acc) {
+		if (n == 0)
+			return acc;
+		else
+			return factorial(n - 1, acc * n);
+	}
+}


### PR DESCRIPTION
This version doesn't causes the `StackOverflowException` when n is big
Long type is used in the return type to avoid int overflow with big multiplications.